### PR TITLE
Upgrade to WildFly-cekit-modules 0.27.9 and maven plugin 1.0.0.Beta3

### DIFF
--- a/builder-image/image-jdk17-overrides.yaml
+++ b/builder-image/image-jdk17-overrides.yaml
@@ -8,6 +8,11 @@ labels:
       value: "jboss-eap8-beta-openjdk17-builder-openshift-container"
     - name: name
       value: *imgName
+
+envs:
+    - name: IMAGE_NAME
+      value: *imgName
+
 modules:
       install:
           - name: jboss.container.openjdk.jdk

--- a/builder-image/image.yaml
+++ b/builder-image/image.yaml
@@ -45,7 +45,7 @@ envs:
       value: org.jboss.eap.plugins
       # TODO To be replaced with actual productized plugin version
     - name: PROVISIONING_MAVEN_PLUGIN_VERSION
-      value: 1.0.0.Alpha3-redhat-00001
+      value: 1.0.0.Beta2-redhat-00001
     - name: SSO_DEFAULT_PROVIDER_NAME
       value: rh-sso
 ports:

--- a/builder-image/image.yaml
+++ b/builder-image/image.yaml
@@ -59,7 +59,7 @@ modules:
           - name: wildfly-cekit-modules
             git:
               url: https://github.com/wildfly/wildfly-cekit-modules
-              ref: 0.27.7
+              ref: 0.27.9
           - name: eap-modules
             path: ../modules
       install:

--- a/builder-image/image.yaml
+++ b/builder-image/image.yaml
@@ -45,7 +45,7 @@ envs:
       value: org.jboss.eap.plugins
       # TODO To be replaced with actual productized plugin version
     - name: PROVISIONING_MAVEN_PLUGIN_VERSION
-      value: 1.0.0.Beta2-redhat-00001
+      value: 1.0.0.Beta3-redhat-00001
     - name: SSO_DEFAULT_PROVIDER_NAME
       value: rh-sso
 ports:

--- a/builder-image/image.yaml
+++ b/builder-image/image.yaml
@@ -59,7 +59,7 @@ modules:
           - name: wildfly-cekit-modules
             git:
               url: https://github.com/wildfly/wildfly-cekit-modules
-              ref: 0.27.5
+              ref: 0.27.7
           - name: eap-modules
             path: ../modules
       install:

--- a/runtime-image/image.yaml
+++ b/runtime-image/image.yaml
@@ -48,7 +48,7 @@ modules:
           - name: wildfly-cekit-modules
             git:
               url: https://github.com/wildfly/wildfly-cekit-modules
-              ref: 0.27.5
+              ref: 0.27.7
           - name: eap-modules
             path: ../modules
       install:

--- a/runtime-image/image.yaml
+++ b/runtime-image/image.yaml
@@ -48,7 +48,7 @@ modules:
           - name: wildfly-cekit-modules
             git:
               url: https://github.com/wildfly/wildfly-cekit-modules
-              ref: 0.27.7
+              ref: 0.27.9
           - name: eap-modules
             path: ../modules
       install:


### PR DESCRIPTION
Changes used to build latest wip images delivered to QE for pre-check.
With fix for JBEAP-23916 and support for WILDFLY_OVERRIDING_ENV_VARS=1