### PR TITLE
Remove the workaround to add cloud and datasources FP to the EAP 8 Beta channel

### DIFF
--- a/tools/2-build-images-from-maven-repo.sh
+++ b/tools/2-build-images-from-maven-repo.sh
@@ -31,26 +31,6 @@ eapVersion=${eapVersion::-1}
 eapVersion=$(basename ${eapVersion})
 echo "EAP8 version is $eapVersion"
 
-eapCloudVersion=$(echo $tmpPath/docker/maven-repository/org/jboss/eap/cloud/eap-cloud-galleon-pack/*/)
-eapCloudVersion=${eapCloudVersion::-1}
-eapCloudVersion=$(basename ${eapCloudVersion})
-echo "EAP 8 eap-cloudcloud-galleon-pack version is $eapCloudVersion"
-
-eapChannelVersion=$(echo $tmpPath/docker/maven-repository/org/jboss/eap/channels/eap-8.0-beta/*/)
-eapChannelVersion=${eapChannelVersion::-1}
-eapChannelVersion=$(basename ${eapChannelVersion})
-echo "EAP 8 Beta channel version is $eapChannelVersion"
-
-echo "Add cloud and datasources FP to org.jboss.eap.channels:eap-8.0-beta:$eapChannelVersion"
-cat <<EOF >> $tmpPath/docker/maven-repository/org/jboss/eap/channels/eap-8.0-beta/$eapChannelVersion/eap-8.0-beta-$eapChannelVersion-channel.yaml
-  - groupId: "org.jboss.eap.cloud"
-    artifactId: "eap-cloud-galleon-pack"
-    version: "$eapCloudVersion"
-  - groupId: "org.jboss.eap"
-    artifactId: "eap-datasources-galleon-pack"
-    version: "$eapVersion"
-EOF
-
 echo "Build JDK11 builder docker image"
 docker_file=$tmpPath/docker/Dockerfile
 cat <<EOF > $docker_file


### PR DESCRIPTION
Latest test release contains it.