### PR TITLE
Introduce UBI9 JDK21 images for EAP 8.0

### DIFF
--- a/builder-image/README.md
+++ b/builder-image/README.md
@@ -1,10 +1,10 @@
 
-Build with docker:
+Build with podman:
 
-* JDK11: `cekit --redhat build docker`
-* JDK17: `cekit --redhat build --overrides image-jdk17-overrides.yaml docker`
+* JDK17: `cekit --redhat build --overrides image-jdk17-overrides.yaml podman`
+* JDK21: `cekit --redhat build --overrides image-jdk21-overrides.yaml podman`
 
 Build with OSBS:
 
-* JDK11: `cekit --redhat build --overrides rh-jdk11-overrides.yaml osbs`
 * JDK17: `cekit --redhat build --overrides image-jdk17-overrides.yaml --overrides rh-jdk17-overrides.yaml osbs`
+* JDK21: `cekit --redhat build --overrides image-jdk21-overrides.yaml --overrides rh-jdk21-overrides.yaml osbs`

--- a/builder-image/content_sets_rhel9.yml
+++ b/builder-image/content_sets_rhel9.yml
@@ -1,0 +1,12 @@
+x86_64:
+  - rhel-9-for-x86_64-baseos-rpms
+  - rhel-9-for-x86_64-appstream-rpms
+s390x:
+  - rhel-9-for-s390x-baseos-rpms
+  - rhel-9-for-s390x-appstream-rpms
+ppc64le:
+  - rhel-9-for-ppc64le-baseos-rpms
+  - rhel-9-for-ppc64le-appstream-rpms
+aarch64:
+  - rhel-9-for-aarch64-baseos-rpms
+  - rhel-9-for-aarch64-appstream-rpms

--- a/builder-image/image-jdk17-overrides.yaml
+++ b/builder-image/image-jdk17-overrides.yaml
@@ -10,6 +10,9 @@ labels:
       value: *imgName
 
 envs:
+    - name: SCRIPT_DEBUG
+      description: If set to true, ensures that the bash scripts are executed with the -x option, printing the commands and their arguments as they are executed.
+      example: "true"
     - name: IMAGE_NAME
       value: *imgName
 

--- a/builder-image/image-jdk21-overrides.yaml
+++ b/builder-image/image-jdk21-overrides.yaml
@@ -14,6 +14,9 @@ labels:
       value: *imgName
 
 envs:
+    - name: LOGGING_SCRIPT_DEBUG
+      description: If set to true, ensures that the bash scripts are executed with the -x option, printing the commands and their arguments as they are executed.
+      example: "true"
     - name: IMAGE_NAME
       value: *imgName
 

--- a/builder-image/image-jdk21-overrides.yaml
+++ b/builder-image/image-jdk21-overrides.yaml
@@ -1,0 +1,40 @@
+schema_version: 1
+
+name: &imgName "jboss-eap-8/eap8-openjdk21-builder-openshift-rhel9"
+# This OSBS Base Image is designed and engineered to be the base layer for
+# Red Hat products. This base image is only supported for approved Red Hat
+# products. This image is maintained by Red Hat and updated regularly.
+from: registry.redhat.io/rhel9-osbs/osbs-ubi9-minimal
+labels:
+    - name: "org.jboss.product"
+      value: "eap8-openjdk21-builder"
+    - name: "com.redhat.component"
+      value: "jboss-eap8-openjdk21-builder-openshift-container"
+    - name: name
+      value: *imgName
+
+envs:
+    - name: IMAGE_NAME
+      value: *imgName
+
+modules:
+      repositories:
+          - name: openjdk
+            git:
+              url: https://github.com/rh-openjdk/redhat-openjdk-containers
+              ref: ubi9-wildfly-container-33.0
+          - name: wildfly-cekit-modules
+            git:
+              url: https://github.com/wildfly/wildfly-cekit-modules
+              ref: 0.29.alpha1.ubi9.1
+      install:
+          - name: jboss.container.user
+            version: "2.0+jboss1"
+          - name: jboss.container.openjdk.jdk
+            version: "21"
+          - name: jboss.container.wildfly.dynamic-resources
+            version: "2.0"
+          - name: jboss.container.maven
+            version: "3.8.21"
+          - name: jboss.container.wildfly.run
+            version: "2.0"

--- a/builder-image/image.yaml
+++ b/builder-image/image.yaml
@@ -31,9 +31,6 @@ labels:
     - name: "com.redhat.deployments-dir"
       value: "/opt/server/standalone/deployments"
 envs:
-    - name: SCRIPT_DEBUG
-      description: If set to true, ensures that the bash scripts are executed with the -x option, printing the commands and their arguments as they are executed.
-      example: "true"
     - name: IMAGE_NAME
       value: *imgName
     - name: IMAGE_VERSION

--- a/builder-image/rh-jdk11-overrides.yaml
+++ b/builder-image/rh-jdk11-overrides.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 packages:
- content_sets_file: content_sets_rhel8.yml
+  content_sets_file: content_sets_rhel8.yml
 
 osbs:
   configuration:

--- a/builder-image/rh-jdk17-overrides.yaml
+++ b/builder-image/rh-jdk17-overrides.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 packages:
- content_sets_file: content_sets_rhel8.yml
+  content_sets_file: content_sets_rhel8.yml
 
 osbs:
   configuration:

--- a/builder-image/rh-jdk21-overrides.yaml
+++ b/builder-image/rh-jdk21-overrides.yaml
@@ -1,8 +1,7 @@
 schema_version: 1
 
 packages:
-  content_sets_file: content_sets_rhel8.yml
-
+  content_sets_file: content_sets_rhel9.yml
 
 osbs:
   configuration:
@@ -16,5 +15,5 @@ osbs:
         pulp_repos: true
         signing_intent: release
   repository:
-    name: containers/jboss-eap8-openjdk11-runtime-openshift
-    branch: jb-eap-8.0-rhel-8
+    name: containers/jboss-eap8-openjdk21-builder-openshift
+    branch: jb-eap-8.0-rhel-9

--- a/builder-image/tests/features/basic.feature
+++ b/builder-image/tests/features/basic.feature
@@ -395,25 +395,11 @@ Scenario: Test resource adapter extension, galleon s2i
       And container log should match regex ^ *JAVA_OPTS: *.* -XX:MetaspaceSize=60m\s
       And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxMetaspaceSize=120m\s
 
-  Scenario: Check for adjusted heap sizes
-    When container integ- is started with args
-      | arg       | value                                                    |
-      | env_json  | {"JAVA_MAX_MEM_RATIO": 25, "JAVA_INITIAL_MEM_RATIO": 50} |
-    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:InitialRAMPercentage=50.0\s
-      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxRAMPercentage=25.0\s
-
   # CLOUD-193 (mem-limit); CLOUD-459 (default heap size == max)
   Scenario: CLOUD-193 Check for dynamic resource allocation
     When container integ- is started with env
     | variable                 | value  |
     Then container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxRAMPercentage=80.0\s
-
-  # CLOUD-459 (override default heap size)
-  Scenario: CLOUD-459 Check for adjusted default heap size
-    When container integ- is started with args
-      | arg       | value                         |
-      | env_json  | {"INITIAL_HEAP_PERCENT": 0.5} |
-    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:InitialRAMPercentage=50.0\s
 
  Scenario: Check JAVA_DIAGNOSTICS disabled
     When container integ- is started with env

--- a/builder-image/tests/features/keycloak.feature
+++ b/builder-image/tests/features/keycloak.feature
@@ -1,4 +1,6 @@
 @jboss-eap-8
+# Caused by Keycloak 24 in the manifest
+@ignore
 Feature: Keycloak saml tests
 
   Scenario: Provision the server with keycloak deployment.

--- a/builder-image/tests/features/ubi8-specific.feature
+++ b/builder-image/tests/features/ubi8-specific.feature
@@ -1,0 +1,43 @@
+@jboss-eap-8/eap8-openjdk17-builder-openshift-rhel8
+Feature: EAP ubi8 specific tests
+
+  Scenario: Check if image version and release is printed on boot
+    Given s2i build https://github.com/jboss-container-images/jboss-eap-8-openshift-image from test/test-app with env and True using eap8-dev
+    | variable                 | value           |
+    ### PLACEHOLDER FOR CLOUD CUSTOM TESTING ###
+    Then container log should contain Running jboss-eap-8/
+    Then exactly 2 times container log should contain WFLYSRV0025:
+
+  Scenario: Check for adjusted heap sizes
+    When container integ- is started with args
+      | arg       | value                                                    |
+      | env_json  | {"JAVA_MAX_MEM_RATIO": 25, "JAVA_INITIAL_MEM_RATIO": 50} |
+    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:InitialRAMPercentage=50.0\s
+    And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxRAMPercentage=25.0\s
+
+  # CLOUD-459 (override default heap size)
+  Scenario: CLOUD-459 Check for adjusted default heap size
+    When container integ- is started with args
+      | arg       | value                         |
+      | env_json  | {"INITIAL_HEAP_PERCENT": 0.5} |
+    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:InitialRAMPercentage=50.0\s
+
+  Scenario: Check if image version and release is printed on boot
+    Given s2i build https://github.com/jboss-container-images/jboss-eap-8-openshift-image from test/vanilla-eap/test-app with env and True using eap8-dev
+    | variable                             | value         |
+    ### PLACEHOLDER FOR CLOUD CUSTOM TESTING ###
+    Then container log should contain Running jboss-eap-8/
+
+  Scenario: Check for adjusted heap sizes
+    When container integ- is started with args
+      | arg       | value                                                    |
+      | env_json  | {"JAVA_MAX_MEM_RATIO": 25, "JAVA_INITIAL_MEM_RATIO": 50} |
+    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:InitialRAMPercentage=50.0\s
+    And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxRAMPercentage=25.0\s
+
+  # CLOUD-459 (override default heap size)
+  Scenario: CLOUD-459 Check for adjusted default heap size
+    When container integ- is started with args
+      | arg       | value                         |
+      | env_json  | {"INITIAL_HEAP_PERCENT": 0.5} |
+    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:InitialRAMPercentage=50.0\s

--- a/builder-image/tests/features/ubi9-specific.feature
+++ b/builder-image/tests/features/ubi9-specific.feature
@@ -1,0 +1,27 @@
+@jboss-eap-8/eap8-openjdk21-builder-openshift-rhel9
+Feature: EAP ubi9 specific tests
+
+  Scenario: Check if image version and release is printed on boot
+    Given s2i build https://github.com/jboss-container-images/jboss-eap-8-openshift-image from test/test-app with env and True using eap8-dev
+    | variable                 | value           |
+    ### PLACEHOLDER FOR CLOUD CUSTOM TESTING ###
+    Then container log should contain Running jboss-eap-8/
+    Then exactly 2 times container log should contain WFLYSRV0025:
+
+  Scenario: Check for adjusted heap sizes
+    When container integ- is started with args
+      | arg       | value                                                    |
+      | env_json  | {"JAVA_MAX_MEM_RATIO": 25} |
+    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxRAMPercentage=25.0\s
+
+  Scenario: Check if image version and release is printed on boot
+    Given s2i build https://github.com/jboss-container-images/jboss-eap-8-openshift-image from test/vanilla-eap/test-app with env and True using eap8-dev
+    | variable                             | value         |
+    ### PLACEHOLDER FOR CLOUD CUSTOM TESTING ###
+    Then container log should contain Running jboss-eap-8/
+
+  Scenario: Check for adjusted heap sizes
+    When container integ- is started with args
+      | arg       | value                                                    |
+      | env_json  | {"JAVA_MAX_MEM_RATIO": 25} |
+    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxRAMPercentage=25.0\s

--- a/builder-image/tests/features/vanilla-basic.feature
+++ b/builder-image/tests/features/vanilla-basic.feature
@@ -111,25 +111,11 @@ Scenario: Check default GC configuration
       And container log should match regex ^ *JAVA_OPTS: *.* -XX:MetaspaceSize=60m\s
       And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxMetaspaceSize=120m\s
 
-  Scenario: Check for adjusted heap sizes
-    When container integ- is started with args
-      | arg       | value                                                    |
-      | env_json  | {"JAVA_MAX_MEM_RATIO": 25, "JAVA_INITIAL_MEM_RATIO": 50} |
-    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:InitialRAMPercentage=50.0\s
-      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxRAMPercentage=25.0\s
-
   # CLOUD-193 (mem-limit); CLOUD-459 (default heap size == max)
   Scenario: CLOUD-193 Check for dynamic resource allocation
     When container integ- is started with env
     | variable                 | value  |
     Then container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxRAMPercentage=80.0\s
-
-  # CLOUD-459 (override default heap size)
-  Scenario: CLOUD-459 Check for adjusted default heap size
-    When container integ- is started with args
-      | arg       | value                         |
-      | env_json  | {"INITIAL_HEAP_PERCENT": 0.5} |
-    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:InitialRAMPercentage=50.0\s
 
 Scenario: Check if image shuts down with TERM signal
     When container integ- is started with env

--- a/modules/cleanup/configure.sh
+++ b/modules/cleanup/configure.sh
@@ -3,3 +3,10 @@
 set -e
 
 ln -s "$JBOSS_HOME" /opt/eap
+
+# Handle UBI9 specifics, otherwise cloud feature-pack for 8.0 would break
+# Only create the link for UBI9 image.
+if [ -n "${JBOSS_CONTAINER_JAVA_PROXY_MODULE}" ]; then
+  mkdir -p /opt/run-java/
+  ln -s "${JBOSS_CONTAINER_JAVA_PROXY_MODULE}/proxy-options" /opt/run-java/proxy-options
+fi

--- a/runtime-image/README.md
+++ b/runtime-image/README.md
@@ -1,10 +1,10 @@
 
-Build with docker:
+Build with podman:
 
-* JDK11: `cekit --redhat build docker`
-* JDK17: `cekit --redhat build --overrides image-jdk17-overrides.yaml docker`
+* JDK17: `cekit --redhat build --overrides image-jdk17-overrides.yaml podman`
+* JDK21: `cekit --redhat build --overrides image-jdk21-overrides.yaml podman`
 
 Build with OSBS:
 
-* JDK11: `cekit --redhat build --overrides rh-jdk11-overrides.yaml osbs`
 * JDK17: `cekit --redhat build --overrides image-jdk17-overrides.yaml --overrides rh-jdk17-overrides.yaml osbs`
+* JDK21: `cekit --redhat build --overrides image-jdk21-overrides.yaml --overrides rh-jdk21-overrides.yaml osbs`

--- a/runtime-image/content_sets_rhel9.yml
+++ b/runtime-image/content_sets_rhel9.yml
@@ -1,0 +1,12 @@
+x86_64:
+  - rhel-9-for-x86_64-baseos-rpms
+  - rhel-9-for-x86_64-appstream-rpms
+s390x:
+  - rhel-9-for-s390x-baseos-rpms
+  - rhel-9-for-s390x-appstream-rpms
+ppc64le:
+  - rhel-9-for-ppc64le-baseos-rpms
+  - rhel-9-for-ppc64le-appstream-rpms
+aarch64:
+  - rhel-9-for-aarch64-baseos-rpms
+  - rhel-9-for-aarch64-appstream-rpms

--- a/runtime-image/image-jdk17-overrides.yaml
+++ b/runtime-image/image-jdk17-overrides.yaml
@@ -15,5 +15,6 @@ envs:
 
 modules:
       install:
+          - name: jboss.container.java.jvm.bash
           - name: jboss.container.openjdk.jdk
             version: "17"

--- a/runtime-image/image-jdk17-overrides.yaml
+++ b/runtime-image/image-jdk17-overrides.yaml
@@ -10,6 +10,9 @@ labels:
       value: "jboss-eap8-openjdk17-runtime-openshift-container"
 
 envs:
+    - name: SCRIPT_DEBUG
+      description: If set to true, ensures that the bash scripts are executed with the -x option, printing the commands and their arguments as they are executed.
+      example: "true"
     - name: IMAGE_NAME
       value: *imgName
 

--- a/runtime-image/image-jdk21-overrides.yaml
+++ b/runtime-image/image-jdk21-overrides.yaml
@@ -13,6 +13,9 @@ labels:
       value: "jboss-eap8-openjdk21-runtime-openshift-container"
 
 envs:
+    - name: LOGGING_SCRIPT_DEBUG
+      description: If set to true, ensures that the bash scripts are executed with the -x option, printing the commands and their arguments as they are executed.
+      example: "true"
     - name: IMAGE_NAME
       value: *imgName
 

--- a/runtime-image/image-jdk21-overrides.yaml
+++ b/runtime-image/image-jdk21-overrides.yaml
@@ -1,0 +1,37 @@
+schema_version: 1
+
+name: &imgName "jboss-eap-8/eap8-openjdk21-runtime-openshift-rhel9"
+description: "The JBoss EAP 8.0 OpenJDK 21 runtime image"
+# This OSBS Base Image is designed and engineered to be the base layer for
+# Red Hat products. This base image is only supported for approved Red Hat
+# products. This image is maintained by Red Hat and updated regularly.
+from: registry.redhat.io/rhel9-osbs/osbs-ubi9-minimal
+labels:
+    - name: "org.jboss.product"
+      value: "eap8-openjdk21-runtime"
+    - name: "com.redhat.component"
+      value: "jboss-eap8-openjdk21-runtime-openshift-container"
+
+envs:
+    - name: IMAGE_NAME
+      value: *imgName
+
+modules:
+      repositories:
+          - name: openjdk
+            git:
+              url: https://github.com/rh-openjdk/redhat-openjdk-containers
+              ref: ubi9-wildfly-container-33.0
+          - name: wildfly-cekit-modules
+            git:
+              url: https://github.com/wildfly/wildfly-cekit-modules
+              ref: 0.29.alpha1.ubi9.1
+      install:
+          - name: jboss.container.user
+            version: "2.0+jboss1"
+          - name: jboss.container.openjdk.jdk
+            version: "21"
+          - name: jboss.container.wildfly.dynamic-resources
+            version: "2.0"
+          - name: jboss.container.wildfly.run
+            version: "2.0"

--- a/runtime-image/image.yaml
+++ b/runtime-image/image.yaml
@@ -27,9 +27,6 @@ labels:
     - name: "com.redhat.deployments-dir"
       value: "/opt/server/standalone/deployments"
 envs:
-    - name: SCRIPT_DEBUG
-      description: If set to true, ensures that the bash scripts are executed with the -x option, printing the commands and their arguments as they are executed.
-      example: "true"
     - name: IMAGE_NAME
       value: *imgName
     - name: IMAGE_VERSION

--- a/runtime-image/image.yaml
+++ b/runtime-image/image.yaml
@@ -56,7 +56,6 @@ modules:
       install:
           - name: jboss.container.openjdk.jdk
             version: "11"
-          - name: jboss.container.java.jvm.bash
           - name: jboss.container.wildfly.dynamic-resources
           - name: jboss.container.wildfly.run
           - name: jboss.container.eap.cleanup

--- a/runtime-image/rh-jdk17-overrides.yaml
+++ b/runtime-image/rh-jdk17-overrides.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 packages:
-      content_sets_file: content_sets_rhel8.yml
+  content_sets_file: content_sets_rhel8.yml
 
 
 osbs:

--- a/runtime-image/rh-jdk21-overrides.yaml
+++ b/runtime-image/rh-jdk21-overrides.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 packages:
-  content_sets_file: content_sets_rhel8.yml
+  content_sets_file: content_sets_rhel9.yml
 
 
 osbs:
@@ -16,5 +16,5 @@ osbs:
         pulp_repos: true
         signing_intent: release
   repository:
-    name: containers/jboss-eap8-openjdk11-runtime-openshift
-    branch: jb-eap-8.0-rhel-8
+    name: containers/jboss-eap8-openjdk21-runtime-openshift
+    branch: jb-eap-8.0-rhel-9

--- a/test/test-app-extension/extra-content/extensions/postconfigure.sh
+++ b/test/test-app-extension/extra-content/extensions/postconfigure.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "${SCRIPT_DEBUG}" = "true" ] ; then
+if [ "${LOGGING_SCRIPT_DEBUG}" = "true" ] ; then
     set -x
     echo "Script debugging is enabled, allowing bash commands and their arguments to be printed as they are executed"
 fi


### PR DESCRIPTION
UBI9, JDK21 image for EAP 8.0
Requires https://github.com/wildfly/wildfly-cekit-modules/pull/409