### PR TITLE
Update examples for EAP 8.1 Beta

### DIFF
--- a/examples/eap/custom-layers/application/pom.xml
+++ b/examples/eap/custom-layers/application/pom.xml
@@ -27,10 +27,10 @@
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <jakarta.jakartaee-api.version>10.0.0</jakarta.jakartaee-api.version>
-        <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
+        <version.maven.war.plugin>3.4.0</version.maven.war.plugin>
         <!-- This env variable is defined in the EAP S2I builder image -->
         <version.eap.plugin>${env.PROVISIONING_MAVEN_PLUGIN_VERSION}</version.eap.plugin>
     </properties>
@@ -84,7 +84,7 @@
                                 <channel>
                                     <manifest>
                                         <groupId>org.jboss.eap.channels</groupId>
-                                        <artifactId>eap-8.0</artifactId>
+                                        <artifactId>eap-8.1</artifactId>
                                     </manifest>
                                 </channel>
                             </channels>

--- a/examples/eap/custom-layers/mariadb-galleon-pack/pom.xml
+++ b/examples/eap/custom-layers/mariadb-galleon-pack/pom.xml
@@ -35,13 +35,19 @@
         <dependency>
             <groupId>org.jboss.eap</groupId>
             <artifactId>wildfly-ee-galleon-pack</artifactId>
-            <version>8.0.5.GA-redhat-00001</version>
+            <version>8.1.0.Beta-redhat-00002</version>
             <type>zip</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
-            <version>2.7.2</version>
+            <version>3.4.1</version>
         </dependency>
     </dependencies>
 <build>                
@@ -49,7 +55,7 @@
             <plugin>
                 <groupId>org.wildfly.galleon-plugins</groupId>
                 <artifactId>wildfly-galleon-maven-plugin</artifactId>
-                <version>6.4.9.Final-redhat-00001</version>
+                <version>7.3.1.Final</version>
                 <executions>
                     <execution>
                         <id>mariadb-galleon-pack-build</id>

--- a/examples/eap/docker-build/Dockerfile
+++ b/examples/eap/docker-build/Dockerfile
@@ -1,4 +1,4 @@
-ARG runtime_image=registry-proxy.engineering.redhat.com/rh-osbs/jboss-eap-8-eap8-openjdk11-runtime-openshift-rhel8:latest
+ARG runtime_image=registry.redhat.io/jboss-eap-8-tech-preview/eap81-openjdk17-builder-openshift-rhel9:latest
 FROM ${runtime_image}
 COPY --chown=jboss:root target/server $JBOSS_HOME
 RUN chmod -R ug+rwX $JBOSS_HOME

--- a/examples/eap/docker-build/README.md
+++ b/examples/eap/docker-build/README.md
@@ -1,13 +1,13 @@
-# Building an EAP 8 application image using docker
+# Building an EAP 8.1 application image using docker
 
-In this example we are making use of the EAP 8 runtime image to build an EAP 8 server + JAX-RS application docker image.
+In this example we are making use of the EAP 8.1 runtime image to build an EAP 8.1 server + JAX-RS application docker image.
 In order to create an EAP 8 server containing our application, we are using the [EAP Maven Plugin](https://github.com/jbossas/eap-maven-plugin).
 
-The docker image is built then deployed on an Openshift cluster using Helm charts for EAP 8.
+The docker image is built then deployed on an Openshift cluster using Helm charts for EAP 8.1.
 
 # Use-cases
 
-* Test EAP 8 new features and/or bug fixes on Openshift.
+* Test EAP 8.1 new features and/or bug fixes on Openshift.
 
 # EAP 8 Maven plugin configuration
 
@@ -40,7 +40,7 @@ Technologies required to build and deploy this example
 
 * docker
 
-* Helm chart for EAP8 `jboss-eap/eap8`.
+* Helm chart for EAP 8.1 `jboss-eap/eap81`.
 
 # Pre-requisites
 
@@ -48,19 +48,19 @@ Technologies required to build and deploy this example
 
 * You have a `Registry Service Account`. You can [create one](https://access.redhat.com/terms-based-registry/) if not.
 
-* You have configured docker to access the EAP 8 images. For detailed instructions check the URL: `https://access.redhat.com/terms-based-registry/#/token/<your user id>/docker-login`.
+* You have configured docker to access the EAP 8.1 images. For detailed instructions check the URL: `https://access.redhat.com/terms-based-registry/#/token/<your user id>/docker-login`.
 
 * You are logged into an OpenShift cluster and have `oc` command in your path
 
 * You have installed Helm. Please refer to [Installing Helm page](https://helm.sh/docs/intro/install/) to install Helm in your environment
 
-* You have installed the repository for the Helm charts for EAP 8
+* You have installed the repository for the Helm charts for EAP 8.1
 
  ```
 helm repo add jboss-eap https://jbossas.github.io/eap-charts/
 ```
 
-* You have built EAP 8 and artifacts are present in your local maven cache
+* You have built EAP 8.1 and artifacts are present in your local maven cache
 
 
 # Example steps
@@ -76,7 +76,7 @@ mvn clean package [-Dversion.eap=<your SNAPSHOT version>]
 2. Build the docker image
 
 ```
-docker build --squash -t eap8-myapp:latest .
+docker build --squash -t eap81-myapp:latest .
 ```
 
 ## Deploy the image on Openshift
@@ -87,7 +87,7 @@ Make sure to set the `OPENSHIFT_IMAGE_REGISTRY` env variable with the actual rou
 When logging to the registry, the route to the registry will be printed on the console.
 
 ```
-export IMAGE=eap8-myapp:latest
+export IMAGE=eap81-myapp:latest
 export OPENSHIFT_NS=$(oc project -q)
 oc registry login
 # Copy the route in the env variable OPENSHIFT_IMAGE_REGISTRY
@@ -100,17 +100,17 @@ docker push  $OPENSHIFT_IMAGE_REGISTRY/$OPENSHIFT_NS/$IMAGE
 2. Enable the pushed image stream resolution
 
 ```
-oc set image-lookup eap8-myapp
+oc set image-lookup eap81-myapp
 ```
 
-3. Deploy the example application using EAP 8 Helm charts
+3. Deploy the example application using EAP 8.1 Helm charts
 
 ```
-helm install eap8-myapp -f helm.yaml jboss-eap/eap8
+helm install eap81-myapp -f helm.yaml jboss-eap/eap81
 ```
 
 4. Access the endpoint
 
 ```
-curl https://$(oc get route eap8-myapp --template='{{ .spec.host }}')/
+curl https://$(oc get route eap81-myapp --template='{{ .spec.host }}')/
 ```

--- a/examples/eap/docker-build/helm.yaml
+++ b/examples/eap/docker-build/helm.yaml
@@ -1,5 +1,5 @@
 image: 
- name: eap8-myapp
+ name: eap81-myapp
 build:
   enabled: false
 deploy:

--- a/examples/eap/docker-build/pom.xml
+++ b/examples/eap/docker-build/pom.xml
@@ -9,14 +9,12 @@
     <name>Demo of a docker build</name>
   
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jakarta.jakartaee-api.version>10.0.0</jakarta.jakartaee-api.version>
-        <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
-        <version.eap.plugin>1.0.0.Beta7-redhat-00001</version.eap.plugin>
-        <version.eap>8.0.0.GA-redhat-00001</version.eap>
-        <version.eap.cloud>1.0.0.GA-redhat-00001</version.eap.cloud>
+        <version.maven.war.plugin>3.4.0</version.maven.war.plugin>
+        <version.eap.plugin>2.0.0.Beta1-redhat-00004</version.eap.plugin>
     </properties>
     
     <dependencies>
@@ -42,12 +40,27 @@
                 <artifactId>eap-maven-plugin</artifactId>
                 <version>${version.eap.plugin}</version>
                 <configuration>
+                    <channels>
+                        <channel>
+                            <manifest>
+                                <groupId>org.jboss.eap.channels</groupId>
+                                <artifactId>eap-8.1</artifactId>
+                            </manifest>
+                        </channel>
+                        <channel>
+                            <manifest>
+                                <groupId>org.jboss.eap.channels</groupId>
+                                <artifactId>wildfly-ee</artifactId>
+                                <version>${version.eap}</version>
+                            </manifest>
+                        </channel>
+                    </channels>
                     <feature-packs>
                         <feature-pack>
-                            <location>org.jboss.eap:wildfly-ee-galleon-pack:${version.eap}</location>
+                            <location>org.jboss.eap:wildfly-ee-galleon-pack</location>
                         </feature-pack>
                         <feature-pack>
-                            <location>org.jboss.eap.cloud:eap-cloud-galleon-pack:${version.eap.cloud}</location>
+                            <location>org.jboss.eap.cloud:eap-cloud-galleon-pack</location>
                         </feature-pack>
                     </feature-packs>
                     <layers>

--- a/examples/eap/legacy-s2i-source-build/README.md
+++ b/examples/eap/legacy-s2i-source-build/README.md
@@ -1,15 +1,15 @@
-# Building an EAP 8 application image using EAP 8 S2I legacy source build
+# Building an EAP 8.1 application image using EAP 8.1 S2I legacy source build
 
 In this example we are building and deploying to OpenShift an application that has been migrated to use Jakarta EE 10 
 but has not been updated to use the [EAP Maven Plugin](https://github.com/jbossas/eap-maven-plugin).
 
 # Use-cases
 
-* User wants to keep the EAP 7.4.x S2I workflow. Start from a github source repository, use latest released EAP 8 artifacts and images.
+* User wants to keep the EAP 7.4.x S2I workflow. Start from a github source repository, use latest released EAP 8.1 artifacts and images.
 
 # Helm Chart provisioning configuration
 
-EAP 8 provisioning configuration (feature-packs, layers and channels) is defined in EAP 8 Helm Chart yaml file.
+EAP 8.1 provisioning configuration (feature-packs, layers and channels) is defined in EAP 8.1 Helm Chart yaml file.
 
 ```
 ...
@@ -21,7 +21,7 @@ build:
     galleonLayers:
       - jaxrs-server
     channels:
-      - org.jboss.eap.channels:eap-8.0
+      - org.jboss.eap.channels:eap-8.1
  ...
 ```
 
@@ -32,7 +32,7 @@ High level view of the Helm Chart configuration.
 * `org.jboss.eap:wildfly-ee-galleon-pack`
 * `org.jboss.eap.cloud:eap-cloud-galleon-pack`
 
-NB, the versions of the feature-packs are retrieved from the latest EAP8 channel: `org.jboss.eap.channels:eap-8.0`
+NB, the versions of the feature-packs are retrieved from the latest EAP 8.1 channel: `org.jboss.eap.channels:eap-8.1`
 
 ## Galleon layers
 
@@ -54,7 +54,7 @@ Extra content packaged inside the provisioned server
 
 Technologies required to build and deploy this example
 
-* Helm chart for EAP8 `jboss-eap/eap8`.
+* Helm chart for EAP 8.1 `jboss-eap/eap81`.
 
 # Pre-requisites
 
@@ -66,7 +66,7 @@ Technologies required to build and deploy this example
 
 * You have installed Helm. Please refer to [Installing Helm page](https://helm.sh/docs/intro/install/) to install Helm in your environment
 
-* You have installed the repository for the Helm charts for EAP 8
+* You have installed the repository for the Helm charts for EAP 8.1
 
  ```
 helm repo add jboss-eap https://jbossas.github.io/eap-charts/
@@ -74,7 +74,7 @@ helm repo add jboss-eap https://jbossas.github.io/eap-charts/
 
 # Example steps
 
-1. Setup to pull EAP 8 s2i builder and runtime images in Openshift [only required for on-premise installation of OpenShift, not needed for OpenShift Sandbox]
+1. Setup to pull EAP 8.1 s2i builder and runtime images in Openshift [only required for on-premise installation of OpenShift, not needed for OpenShift Sandbox]
 
 Create the authentication token secret for your OpenShift project using the YAML file that you downloaded:
 
@@ -90,14 +90,14 @@ oc secrets link default 1234567-myserviceaccount-pull-secret --for=pull
 oc secrets link builder 1234567-myserviceaccount-pull-secret --for=pull
 ```
 
-2. Deploy the example application using EAP 8 Helm charts
+2. Deploy the example application using EAP 8.1 Helm charts
 
 ```
-helm install eap8-source-build-app -f helm.yaml jboss-eap/eap8
+helm install eap81-source-build-app -f helm.yaml jboss-eap/eap81
 ```
 
 3. Access the endpoint
 
 ```
-curl https://$(oc get route eap8-source-build-app --template='{{ .spec.host }}')/
+curl https://$(oc get route eap81-source-build-app --template='{{ .spec.host }}')/
 ```

--- a/examples/eap/legacy-s2i-source-build/helm.yaml
+++ b/examples/eap/legacy-s2i-source-build/helm.yaml
@@ -2,7 +2,7 @@ build:
   uri: https://github.com/jboss-container-images/jboss-eap-8-openshift-image
   mode: s2i
   contextDir: examples/eap/legacy-s2i-source-build
-  ref: 8.0.0.GA
+  ref: 8.1.0.BETA
   s2i:
     featurePacks:
       - org.jboss.eap:wildfly-ee-galleon-pack
@@ -10,6 +10,6 @@ build:
     galleonLayers:
       - jaxrs-server
     channels:
-      - org.jboss.eap.channels:eap-8.0
+      - org.jboss.eap.channels:eap-8.1
 deploy:
   replicas: 1

--- a/examples/eap/legacy-s2i-source-build/pom.xml
+++ b/examples/eap/legacy-s2i-source-build/pom.xml
@@ -9,11 +9,11 @@
     <name>Legacy application</name>
   
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jakarta.jakartaee-api.version>10.0.0</jakarta.jakartaee-api.version>
-        <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
+        <version.maven.war.plugin>3.4.0</version.maven.war.plugin>
     </properties>
     
     <dependencies>

--- a/examples/eap/s2i-binary-build/README.md
+++ b/examples/eap/s2i-binary-build/README.md
@@ -1,13 +1,13 @@
-# Building an EAP 8 application image using EAP 8 S2I binary build
+# Building an EAP 8 application image using EAP 8.1 S2I binary build
 
-In this example we are making use of the EAP 8 S2I builder image to build an EAP 8 server + JAX-RS application docker image on Openshift.
-In order to create an EAP 8 server containing our application, we are using the [EAP Maven Plugin](https://github.com/jbossas/eap-maven-plugin).
+In this example we are making use of the EAP 8.1 S2I builder image to build an EAP 8.1 server + JAX-RS application docker image on Openshift.
+In order to create an EAP 8.1 server containing our application, we are using the [EAP Maven Plugin](https://github.com/jbossas/eap-maven-plugin).
 
 # Use-cases
 
-* Test EAP 8 new features and/or bug fixes on Openshift.
+* Test EAP 8.1 new features and/or bug fixes on Openshift.
 
-# EAP 8 Maven plugin configuration
+# EAP 8.1 Maven plugin configuration
 
 High level view of the EAP Maven plugin configuration.
 
@@ -46,7 +46,7 @@ Technologies required to build and deploy this example
 
 * You are logged into an OpenShift cluster and have `oc` command in your path
 
-* You have built EAP 8 and artifacts are present in your local maven cache
+* You have built EAP 8.1 and artifacts are present in your local maven cache
 
 # Example steps
 
@@ -79,38 +79,38 @@ oc secrets link builder 1234567-myserviceaccount-pull-secret --for=pull
 2. Import the EAP 8 s2i Builder image in Openshift
 
 ```
-oc import-image jboss-eap-8/eap8-openjdk11-builder-openshift-rhel8:latest --from=registry.redhat.io/jboss-eap-8/eap8-openjdk11-builder-openshift-rhel8:latest --confirm
+oc import-image registry.redhat.io/jboss-eap-8-tech-preview/eap81-openjdk17-builder-openshift-rhel9:latest --from=registry.redhat.io/jboss-eap-8-tech-preview/eap81-openjdk17-builder-openshift-rhel9:latest --confirm
 ```
 
 3. Create the binary build.
 
 ```
-oc new-build --strategy source --binary --image-stream eap8-openjdk11-builder-openshift-rhel8 --name eap8-binary-build-app-build
+oc new-build --strategy source --binary --image-stream eap81-openjdk17-builder-openshift-rhel9 --name eap81-binary-build-app-build
 ```
 
 4. Start a binary build from the full server that will output the application image.
 
 ```
-oc start-build eap8-binary-build-app-build --from-dir target/server
+oc start-build eap81-binary-build-app-build --from-dir target/server
 ```
 
-4.1 [Alternative] Start a binary build from the deployment only that will provision the EAP8 server, deploy the deployment and output the application image.
+4.1 [Alternative] Start a binary build from the deployment only that will provision the EAP 8.1 server, deploy the deployment and output the application image.
 
 ```
-oc start-build eap8-binary-build-app-build --from-file target/ROOT.war --env GALLEON_PROVISION_LAYERS=jaxrs-server \
+oc start-build eap81-binary-build-app-build --from-file target/ROOT.war --env GALLEON_PROVISION_LAYERS=jaxrs-server \
 --env GALLEON_PROVISION_FEATURE_PACKS="org.jboss.eap:wildfly-ee-galleon-pack,org.jboss.eap.cloud:eap-cloud-galleon-pack" \
---env GALLEON_PROVISION_CHANNELS="org.jboss.eap.channels:eap-8.0"
+--env GALLEON_PROVISION_CHANNELS="org.jboss.eap.channels:eap-8.1"
 ```
 
 5. Deploy the example application
 
 ```
-oc new-app eap8-binary-build-app
-oc expose svc/eap8-binary-build-app
+oc new-app eap81-binary-build-app
+oc expose svc/eap81-binary-build-app
 ```
 
 6. Access the endpoint
 
 ```
-curl https://$(oc get route eap8-binary-build-app --template='{{ .spec.host }}')/
+curl https://$(oc get route eap81-binary-build-app --template='{{ .spec.host }}')/
 ```

--- a/examples/eap/s2i-binary-build/pom.xml
+++ b/examples/eap/s2i-binary-build/pom.xml
@@ -9,12 +9,12 @@
     <name>SampleApp</name>
   
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jakarta.jakartaee-api.version>10.0.0</jakarta.jakartaee-api.version>
-        <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
-        <version.eap.plugin>1.0.1.Final-redhat-00008</version.eap.plugin>
+        <version.maven.war.plugin>3.4.0</version.maven.war.plugin>
+        <version.eap.plugin>2.0.0.Beta1-redhat-00004</version.eap.plugin>
     </properties>
     
     <dependencies>
@@ -44,7 +44,14 @@
                         <channel>
                             <manifest>
                                 <groupId>org.jboss.eap.channels</groupId>
-                                <artifactId>eap-8.0</artifactId>
+                                <artifactId>eap-8.1</artifactId>
+                            </manifest>
+                        </channel>
+                        <channel>
+                            <manifest>
+                                <groupId>org.jboss.eap.channels</groupId>
+                                <artifactId>wildfly-ee</artifactId>
+                                <version>${version.eap}</version>
                             </manifest>
                         </channel>
                     </channels>

--- a/examples/eap/s2i-source-build/README.md
+++ b/examples/eap/s2i-source-build/README.md
@@ -1,11 +1,11 @@
-# Building an EAP 8 application image using EAP 8 S2I source build
+# Building an EAP 8 application image using EAP 8.1 S2I source build
 
-In this example we are making use of the EAP 8 S2I builder and runtime images to build an EAP 8 server + JAX-RS application docker image on Openshift.
+In this example we are making use of the EAP 8.1 S2I builder and runtime images to build an EAP 8.1 server + JAX-RS application docker image on Openshift.
 In order to create an EAP 8 server containing our application, we are using the [EAP Maven Plugin](https://github.com/jbossas/eap-maven-plugin).
 
 # Use-cases
 
-* User typical S2I workflow. Start from a github source repository, use latest released EAP 8 artifacts and images.
+* User typical S2I workflow. Start from a github source repository, use latest released EAP 8.1 artifacts and images.
 
 # EAP 8 Maven plugin configuration
 
@@ -16,7 +16,7 @@ High level view of the EAP Maven plugin configuration.
 * `org.jboss.eap:wildfly-ee-galleon-pack`
 * `org.jboss.eap.cloud:eap-cloud-galleon-pack`
 
-NB, the versions of the feature-packs are retrieved from the latest EAP8 channel: `org.jboss.eap.channels:eap-8.0`
+NB, the versions of the feature-packs are retrieved from the latest EAP 8.1 channel: `org.jboss.eap.channels:eap-8.1`
 
 ## Galleon layers
 
@@ -38,7 +38,7 @@ Extra content packaged inside the provisioned server
 
 Technologies required to build and deploy this example
 
-* Helm chart for EAP8 `jboss-eap/eap8`.
+* Helm chart for EAP 8.1 `jboss-eap/eap81`.
 
 # Pre-requisites
 
@@ -50,7 +50,7 @@ Technologies required to build and deploy this example
 
 * You have installed Helm. Please refer to [Installing Helm page](https://helm.sh/docs/intro/install/) to install Helm in your environment
 
-* You have installed the repository for the Helm charts for EAP 8
+* You have installed the repository for the Helm charts for EAP 8.1
 
  ```
 helm repo add jboss-eap https://jbossas.github.io/eap-charts/
@@ -58,7 +58,7 @@ helm repo add jboss-eap https://jbossas.github.io/eap-charts/
 
 # Example steps
 
-1. Setup to pull EAP 8 s2i builder and runtime images in Openshift [only required for on-premise installation of OpenShift, not needed for OpenShift Sandbox]
+1. Setup to pull EAP 8.1 s2i builder and runtime images in Openshift [only required for on-premise installation of OpenShift, not needed for OpenShift Sandbox]
 
 Create the authentication token secret for your OpenShift project using the YAML file that you downloaded:
 
@@ -77,11 +77,11 @@ oc secrets link builder 1234567-myserviceaccount-pull-secret --for=pull
 2. Deploy the example application using EAP 8 Helm charts
 
 ```
-helm install eap8-source-build-app -f helm.yaml jboss-eap/eap8
+helm install eap81-source-build-app -f helm.yaml jboss-eap/eap81
 ```
 
 3. Access the endpoint
 
 ```
-curl https://$(oc get route eap8-source-build-app --template='{{ .spec.host }}')/
+curl https://$(oc get route eap81-source-build-app --template='{{ .spec.host }}')/
 ```

--- a/examples/eap/s2i-source-build/helm.yaml
+++ b/examples/eap/s2i-source-build/helm.yaml
@@ -1,7 +1,7 @@
 build:
   uri: https://github.com/jboss-container-images/jboss-eap-8-openshift-image
   contextDir: examples/eap/s2i-source-build
-  ref: 8.0.0.GA
+  ref: 8.1.0.BETA
 deploy:
   replicas: 1
     

--- a/examples/eap/s2i-source-build/pom.xml
+++ b/examples/eap/s2i-source-build/pom.xml
@@ -9,11 +9,11 @@
     <name>A JAXRS demo</name>
   
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jakarta.jakartaee-api.version>10.0.0</jakarta.jakartaee-api.version>
-        <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
+        <version.maven.war.plugin>3.4.0</version.maven.war.plugin>
         <!-- This env variable is defined in the EAP S2I builder image -->
         <version.eap.plugin>${env.PROVISIONING_MAVEN_PLUGIN_VERSION}</version.eap.plugin>
     </properties>
@@ -45,7 +45,7 @@
                         <channel>
                             <manifest>
                                 <groupId>org.jboss.eap.channels</groupId>
-                                <artifactId>eap-8.0</artifactId>
+                                <artifactId>eap-8.1</artifactId>
                             </manifest>
                         </channel>
                     </channels>


### PR DESCRIPTION
Update the examples to run with EAP 8.1. All dependencies are NOT the final ones.

Prior to release EAP 8.1 Beta, this JIRA: https://issues.redhat.com/browse/JBEAP-29450 must be fixed (update dependencies with released ones).
