### PR TITLE
[JBEAP-28242] Prepare container images for EAP 8.1 GA

### DIFF
--- a/builder-image/image-jdk21-overrides.yaml
+++ b/builder-image/image-jdk21-overrides.yaml
@@ -1,11 +1,11 @@
 schema_version: 1
 
-name: &imgName "jboss-eap-8-tech-preview/eap81-openjdk21-builder-openshift-rhel9"
+name: &imgName "jboss-eap-8/eap81-openjdk21-builder-openshift-rhel9"
 labels:
     - name: "org.jboss.product"
       value: "eap81-openjdk21-builder"
     - name: "com.redhat.component"
-      value: "jboss-eap81-beta-openjdk21-builder-openshift-container"
+      value: "jboss-eap81-openjdk21-builder-openshift-container"
     - name: name
       value: *imgName
 

--- a/builder-image/image.yaml
+++ b/builder-image/image.yaml
@@ -43,7 +43,7 @@ envs:
     - name: PROVISIONING_MAVEN_PLUGIN_GROUP_ID
       value: org.jboss.eap.plugins
     - name: PROVISIONING_MAVEN_PLUGIN_VERSION
-      value: 2.0.0.Final-redhat-00003
+      value: 2.0.0.Final-redhat-00004
     - name: SSO_DEFAULT_PROVIDER_NAME
       value: rh-sso
 ports:

--- a/builder-image/image.yaml
+++ b/builder-image/image.yaml
@@ -1,8 +1,8 @@
 schema_version: 1
 
-name: &imgName "jboss-eap-8-tech-preview/eap81-openjdk17-builder-openshift-rhel9"
+name: &imgName "jboss-eap-8/eap81-openjdk17-builder-openshift-rhel9"
 description: "Red Hat JBoss Enterprise Application Platform 8.1 OpenShift S2I Builder image."
-version: &imgVersion "1.0.0.Beta"
+version: &imgVersion "1.0.0.GA"
 from: "registry.access.redhat.com/ubi9/ubi-minimal"
 # Warning, we must use cekit min version 4.3.0 in order for the labels to be set at the end of the build and override JDK modules ones.
 labels:
@@ -13,7 +13,7 @@ labels:
     - name: "org.jboss.product.version"
       value: *imgVersion
     - name: "com.redhat.component"
-      value: "jboss-eap81-beta-openjdk17-builder-openshift-container"
+      value: "jboss-eap81-openjdk17-builder-openshift-container"
     - name: io.k8s.description
       value: "Platform for building and running Jakarta EE applications on JBoss EAP 8.1"
     - name: io.k8s.display-name

--- a/builder-image/rh-jdk17-overrides.yaml
+++ b/builder-image/rh-jdk17-overrides.yaml
@@ -16,5 +16,5 @@ osbs:
         pulp_repos: true
         signing_intent: release
   repository:
-    name: containers/jboss-eap81-beta-openjdk17-builder-openshift 
+    name: containers/jboss-eap81-openjdk17-builder-openshift
     branch: jb-eap-8.1-rhel-9

--- a/builder-image/rh-jdk21-overrides.yaml
+++ b/builder-image/rh-jdk21-overrides.yaml
@@ -16,5 +16,5 @@ osbs:
         pulp_repos: true
         signing_intent: release
   repository:
-    name: containers/jboss-eap81-beta-openjdk21-builder-openshift
+    name: containers/jboss-eap81-openjdk21-builder-openshift
     branch: jb-eap-8.1-rhel-9

--- a/runtime-image/image-jdk21-overrides.yaml
+++ b/runtime-image/image-jdk21-overrides.yaml
@@ -1,13 +1,13 @@
 schema_version: 1
 
-name: &imgName "jboss-eap-8-tech-preview/eap81-openjdk21-runtime-openshift-rhel9"
+name: &imgName "jboss-eap-8/eap81-openjdk21-runtime-openshift-rhel9"
 description: "The JBoss EAP 8.1 OpenJDK 21 runtime image"
 
 labels:
     - name: "org.jboss.product"
       value: "eap81-openjdk21-runtime"
     - name: "com.redhat.component"
-      value: "jboss-eap81-beta-openjdk21-runtime-openshift-container"
+      value: "jboss-eap81-openjdk21-runtime-openshift-container"
 
 envs:
     - name: IMAGE_NAME

--- a/runtime-image/image.yaml
+++ b/runtime-image/image.yaml
@@ -1,8 +1,8 @@
 schema_version: 1
 
-name: &imgName "jboss-eap-8-tech-preview/eap81-openjdk17-runtime-openshift-rhel9"
+name: &imgName "jboss-eap-8/eap81-openjdk17-runtime-openshift-rhel9"
 description: "The JBoss EAP 8.1 OpenJDK 17 runtime image"
-version: &imgVersion "1.0.0.Beta"
+version: &imgVersion "1.0.0.GA"
 from: "registry.access.redhat.com/ubi9/ubi-minimal"
 # Warning, we must use cekit min version 4.3.0 in order for the labels to be set at the end of the build and override JDK modules ones.
 labels:
@@ -11,7 +11,7 @@ labels:
     - name: "org.jboss.product.version"
       value: *imgVersion
     - name: "com.redhat.component"
-      value: "jboss-eap81-beta-openjdk17-runtime-openshift-container"
+      value: "jboss-eap81-openjdk17-runtime-openshift-container"
     - name: "io.k8s.description"
       value: "Base image to run an EAP 8.1 server and application"
     - name: "io.k8s.display-name"

--- a/runtime-image/rh-jdk17-overrides.yaml
+++ b/runtime-image/rh-jdk17-overrides.yaml
@@ -17,5 +17,5 @@ osbs:
         pulp_repos: true
         signing_intent: release
   repository:
-    name: containers/jboss-eap81-beta-openjdk17-runtime-openshift
+    name: containers/jboss-eap81-openjdk17-runtime-openshift
     branch: jb-eap-8.1-rhel-9

--- a/runtime-image/rh-jdk21-overrides.yaml
+++ b/runtime-image/rh-jdk21-overrides.yaml
@@ -17,5 +17,5 @@ osbs:
         pulp_repos: true
         signing_intent: release
   repository:
-    name: containers/jboss-eap81-beta-openjdk21-runtime-openshift
+    name: containers/jboss-eap81-openjdk21-runtime-openshift
     branch: jb-eap-8.1-rhel-9


### PR DESCRIPTION
Update image name, brew components to prepare for the release of EAP 8.1 GA OpenShift images.

JIRA: https://issues.redhat.com/browse/JBEAP-28242